### PR TITLE
Init-InstallSources.ps1 fails if install directory doesnt exist

### DIFF
--- a/inc/Params.ps1
+++ b/inc/Params.ps1
@@ -191,5 +191,8 @@ if (-not(Test-Path -PathType Container $save_dir)) {
 	New-Item -ItemType Directory -Path $save_dir
 }
 
+if (-not(Test-Path -PathType Container $install)) {
+	New-Item -ItemType Directory -Path $install
+}
 
 


### PR DESCRIPTION
To fix this we need to create the $install_path/$os directory
