### PR TITLE
Dont try to install dotnet if it doesnt exist

### DIFF
--- a/inc/Functions.ps1
+++ b/inc/Functions.ps1
@@ -265,8 +265,10 @@ function AddUpdates([string]$updates_dir, [string]$mount_dir, [string]$wim_image
 		#Array to hold package locations
 		$package_path = @()
 		
-		Write-Host "Installing .Net 3.5 from $sources"
-		Invoke-Expression "& '$dism' /image:$mount_dir /Enable-Feature /FeatureName:NetFx3 /all /source:$sources\sources\sxs"
+		if (Test-Path -PathType Container $sources\sources\sxs) {
+			Write-Host "Installing .Net 3.5 from $sources"
+			Invoke-Expression "& '$dism' /image:$mount_dir /Enable-Feature /FeatureName:NetFx3 /all /source:$sources\sources\sxs"
+		}
 
 		InstallPackages($updates_dir)
 	} else {


### PR DESCRIPTION
Noticed that dotnet integration fails if the OS media does not contain it
