### PR TITLE
10_init.cmd fails due to undefined %deployRoot%

### DIFF
--- a/tools/install.root/wimaging/_config.cmd.sample
+++ b/tools/install.root/wimaging/_config.cmd.sample
@@ -1,4 +1,5 @@
 :: Image Tools Config File
+set deployRoot=%wimagingRoot%\deploy
 set logfile=c:\SetupDebug.log
 set deployment=deployment.company.com
 set username=domain\deployment-user


### PR DESCRIPTION
Need %deployRoot% defined in _config.cmd
