### PR TITLE
Removing cmdkey responsible for adding credentials

### DIFF
--- a/tools/install.root/wimaging/deploy/10_init.cmd
+++ b/tools/install.root/wimaging/deploy/10_init.cmd
@@ -2,9 +2,6 @@
 cd /d %~dp0
 call %wimagingRoot%\_config.cmd
 
-echo Adding credentials for %deployment%
-cmdkey /add:%deployment% /user:%username% /pass:%password%
-
 echo Downloading 20_finish.cmd
 cscript.exe //NoLogo %deployRoot%\wget.vbs http://%foremanserver%/unattended/finish %deployRoot%\finish_unix.cmd
 


### PR DESCRIPTION
I don't think this is required since the finish script does the following anyway:

<pre>
 echo Adding Credentials
  psexec.exe -accepteula -h -u %tempAdminUser% -p %tempAdminPassword% cmd /c "cmdkey /add:%deploymentShare% /user:%netUser% /pass:%netPassword%"
</pre>


An added benefit is that the `%deploymentShare%` can be dynamically sourced from foreman.
