### PR TITLE
Fixed a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join the chat at https://gitter.im/kireevco/wimaging](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/kireevco/wimaging?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Introduction
-`wimaging` a set of scripts to prepare WIM images and templates for Foreman to provision Windows hosts.
+`wimaging` is a set of scripts to prepare WIM images and templates for Foreman to provision Windows hosts.
 Most of the time official Microsoft deployment tools are used; mostly `dism.exe`.
 
 All relevant configuration files like `unattend.xml` are rendered by Foreman and downloaded at build time.
@@ -11,14 +11,14 @@ All relevant configuration files like `unattend.xml` are rendered by Foreman and
 ### Features
 - __Linux style installation__ using `http://` or `ftp://` installation media
 - __No extra servers__ like WDS needed - all relevant settings can be configured in Foreman directly
-- __Official Mircosoft utilities__ are used for all relevant setup stages making it easy to add (future) operating systems
+- __Official Microsoft utilities__ are used for all relevant setup stages making it easy to add (future) operating systems
 - __Driver installation__ during build time
 - Support for __localization__ settings (like time zone, locale, UI language)
 - Optional __domain join__ including target OU
 - Optional __local user creation__
 - Support for Foreman's __root password__ using Base64 encoding
 - Correctly __report finished host building__
-- Optional software installation and user tasks at the end of the build (like __installing puppet__ ect)
+- Optional software installation and user tasks at the end of the build (like __installing puppet__ etc)
 
 ## Prerequisites:
 The list requirements for using Foreman, all of them are __not__ covered by this guide.
@@ -53,7 +53,7 @@ Simple as that. For Bare Metal hosts [Foreman discovery](https://github.com/thef
   1. Drive 0 is cleaned, partitioned and mounted using foreman partition table (simple `diskpart` script)
   4. `install.wim` is downloaded via http/ftp and applied using `dism.exe`
   5. `unattend.xml` (`foreman_url('provision')`) is download and applied using `dism.exe`
-  6. Drivers are download and added using `dism.exe`
+  6. Drivers are downloaded and added using `dism.exe`
   6. Required tools are added to the new host (most prominently `wget`)
   6. Optionally, download extra software (like puppet)
   6. Optionally, domain join script (`foreman_url('user_data')`)

--- a/doc/foreman.md
+++ b/doc/foreman.md
@@ -21,7 +21,7 @@ In _Hosts -> Architectures_ add a new architecture:
 - Name: `x64`
 
 Add a new OS in _Hosts -> Operating systems_ if needed.
-If you already have windows hosts and puppet, the correct OS and architecture has been auto created already.
+If you already have windows hosts and puppet, the correct OS and architecture have been auto created already.
 This example covers Windows 8.1 / Windows Server 2012R2.
 
 ![Add new OS](img/forman_os.png "Adding Windows 8 OS in Foreman")
@@ -88,7 +88,7 @@ If you want to disguise your password, you could add a host parameter `localUser
 <%= Base64.encode64(Encoding::Converter.new("UTF-8", "UTF-16LE",:undef => nil).convert(@host.params['localUserPassword']+"Password")).delete!("\n").chomp -%>
 ```
 
-Note,  the string`Password` is appended your passwords. You can try this out with by generating an unattend.xml containing local users using WAIK.
+Note,  the string `Password` is appended your passwords. You can try this out with by generating an unattend.xml containing local users using WAIK.
 
 #### WAIK extraFinishCommands
 - Name: `WAIK extraFinishCommands`
@@ -133,7 +133,7 @@ required and have defaults. For the most up to date desciption see the template 
 ### Important parameters
 #### Required
 - `windowsLicenseKey`: Valid Windows license key or generic KMS key
-- `windowsLicenseOwner`:Legal owner of the Windows license key
+- `windowsLicenseOwner`: Legal owner of the Windows license key
 - `wimImageName`: WIM image to install from a multi image install.wim file.
 
 #### Optional
@@ -152,8 +152,8 @@ The following parameters are only applied if they exist. Some, like `domainAdmin
 ## VII. Testing and Troubleshooting
 The templates most likely need a lot of testing to work. This is not covered here; though some hints how to start. You should proceed in this order:
 
-1. __Get your templates to render correctly__. Create random `Bare Metal` host in the desired hostgroup for this purpose and make extensive use of foreman's excellent template __Preview__.
-2. __Continue tesing with VMs__ to test netbooting and basic installation
+1. __Get your templates to render correctly__. Create a random `Bare Metal` host in the desired hostgroup for this purpose and make extensive use of foreman's excellent template __Preview__.
+2. __Continue testing with VMs__ to test netbooting and basic installation
 3. __Debug `peSetup.cmd`__ by pausing it at the send (remove the comment from `::PAUSE`). Then, use `Ctrl-C` to cancel the script altogether. This way you can debug the rendered `peSetup.cmd` quite nicely in WinPE (eg, `notepad peSetup.cmd`)
-4. Use a manual installed host to test rendered snippets like `WAIK extraFinishCommands` directly.
+4. Use a manually installed host to test rendered snippets like `WAIK extraFinishCommands` directly.
 4. __Examine `C:\foreman.log.`__ - the output left from the finish script. Also, comment out the clean up stage in the finish script to examine and test the rendered scripts directly.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -2,7 +2,7 @@
 - ```Init-InstallSources.ps1```: Copies ISO files to wimaging.
 - ```Init-WorkWim.ps1```: Initializes work .wim file from sources
 - ```Update-All.ps1```: Triggers full-cycle .wim process.
-- ```Backup-WorkWim.ps1```: Backs up current .wim (in case you don't want to loose your changes).
+- ```Backup-WorkWim.ps1```: Backs up current .wim (in case you don't want to lose your changes).
 - ```Push-WimBoot.ps1```: Pushes current work boot.wim to install dirrectory, which makes it available over network.
 - ```Unmount-VHD.ps1```: Unmounts VHD
 - ```Update-BootAll.ps1```

--- a/doc/wimaging.md
+++ b/doc/wimaging.md
@@ -18,7 +18,7 @@ Relevant folders only. All steps are covered below; just so you know your way ar
 - `./tools` - files and utilities witch are injected to the WIM files are located here
 
 ## I. Setup your "Technician Computer"
-Plan on with operating systems / images you want to serve. For a list of possible
+Plan on which operating systems / images you want to serve. For a list of possible
 choices see `./inc/Config.ps1.sample`.
 If your OS is not listed, it is quite easy do add new ones, see further below.
 
@@ -57,10 +57,10 @@ Since this is used to test networking the WinPE stage, any pingable IP will do h
 
 ### Adding extras, drivers and boot files
 1. Create a copy of `./install/directory.template` in `./install/`. Name it after the OS name found in `Config.ps1`.
-2. Repeat for each os
+2. Repeat for each OS
 2. The template for Windows PE is already prepared; but still check whatever it need changes
-5. Copy boot files from `./sources/<os>/boot/*` do `boot/`. These will later be download by foreman-proxy.
-6. Copy `winpe.wim` from WAIK  to `./sources/windows-pe-x64/`
+5. Copy boot files from `./sources/<os>/boot/*` to `boot/`. These will later be downloaded by foreman-proxy.
+6. Copy `winpe.wim` from WAIK to `./sources/windows-pe-x64/`
 
 ## III. Prepare `install.wim` and `boot.wim`
 Start `./run-wimaging-shell.cmd`. From the menu, select the configuration for the session.
@@ -73,7 +73,7 @@ To show the menu again, run `./Show-Menu.ps1`. Go through all your operating sys
 
 ### Adding drivers and extras
 - Copy drivers and extras to the respective folders in `./install/<osname>`. The folder structure below `drivers/` does not matter, all drivers present will be added recursively.
-- The `extra/` folder is optional. The structure in there is up to you. If you just want to sick with the provided template, download the puppet version you need and rename it `puppet.msi`.
+- The `extra/` folder is optional. The structure in there is up to you. If you just want to stick with the provided template, download the puppet version you need and rename it `puppet.msi`.
 
 ### Creating `boot.wim`
 One winpe image will serve as boot file for your all operating systems.
@@ -92,7 +92,7 @@ Alternatively, you can run each step separately with the respective commands. Th
 
 ## IV. Sync `./install` folder to your file server.
 __Notes___: The file server must share these files via `http://` and/or `ftp://`.
-Test if this share is accessible. If you like, you can use the same host; for instance by stalling IIS (not covered).
+Test if this share is accessible. If you like, you can use the same host; for instance by installing IIS (not covered).
 Alternatively, set `$install_root` in `Config.ps1` to point directly to a network location.
 
 ## V. Configure Foreman


### PR DESCRIPTION
I found one typo in `foreman.md` that I did _not_ fix: `ntpSever` should be `ntpServer`.  But that typo is actually in the code, so the code (in Foreman?) should be changed as well.  And probably the current (misspelled) name should be accepted for backwards compatibility.  If you want, I can propose PRs for this as well.

PS. thanks a lot for your work on this! I found it by accident on the Foreman mailing list.  Right now I'm also working on Windows imaging automation, but for OpenStack and not using Foreman.  So I won't be using this right now, but I'm impressed.  The documentation reads well and shows that a lot of thought has gone into this.